### PR TITLE
Update README for Snowflake Documentation Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,47 @@
-# Terraform Provider Documentation Builder
+# Snowflake Terraform Provider Documentation Builder
 
-A utility to build a text documentation of a Terraform provider hosted on the [Terraform Registry](https://registry.terraform.io/). This is useful for feeding into LLMs for reference and providing exact and up-to-date knowledge.
+This utility builds a single-file Markdown documentation for the Snowflake Terraform Provider. It fetches the documentation from the official `snowflakedb/terraform-provider-snowflake` GitHub repository and consolidates it into one file. This is useful for providing a comprehensive, searchable reference for local use.
 
-## Features
+## Prerequisites
 
-*   Fetches provider documentation from the Terraform Registry.
-*   Converts the documentation into a clean text format.
-*   Outputs a single text file for easy use with LLMs.
+This tool relies on a few common command-line utilities that are typically available in a standard Unix-like environment (such as Linux, macOS, or Windows Subsystem for Linux).
 
-## Getting Started
-
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
-
-### Prerequisites
-
-*   Python 3.8+
-*   pip
-*   venv
-
-### Installation
-
-1.  **Clone the repository:**
-
-    ```sh
-    git clone https://github.com/alexeie/build_tf_provider_docs.git
-    cd build_tf_provider_docs
-    ```
-
-2.  **Create and activate a virtual environment:**
-
-    Using `bash` or `zsh`:
-    ```sh
-    python3 -m venv venv
-    source venv/bin/activate
-    ```
-
-3.  **Install the dependencies:**
-
-    ```sh
-    pip install -r requirements.txt
-    ```
+*   `curl`: Used to fetch data from URLs.
+*   `grep`, `awk`, `sed`, `basename`: Standard text-processing utilities.
+*   `python`: Used to run the script that generates the list of documentation URLs. No external libraries are needed.
 
 ## Usage
 
-To use the script, run it from the command line with the following arguments:
+Follow these steps to generate the documentation from scratch.
+
+### Step 1: Fetch the Repository File Structure
+
+The first step is to get the file structure of the Snowflake Terraform Provider's documentation directory. This is done by querying the GitHub API and saving the output to a file named `github_tree.json`.
+
+Run the following command in your terminal:
 
 ```sh
-python main.py --provider <provider_name> --output <output_file>
+curl -s "https://api.github.com/repos/snowflakedb/terraform-provider-snowflake/git/trees/main?recursive=1" -o github_tree.json
 ```
 
-For example:
+This will create the `github_tree.json` file in your current directory.
+
+### Step 2: Generate the List of Documentation URLs
+
+Next, run the provided Python script to process `github_tree.json`. This script extracts the paths to the relevant documentation files, constructs the full URLs, and saves them into a file named `urls.txt`.
+
 ```sh
-python main.py --provider hashicorp/aws --output aws_provider_docs.txt
+python scrape.py
 ```
 
-## Contributing
+This will create the `urls.txt` file.
 
-Contributions are welcome! Please open an issue or submit a pull request.
+### Step 3: Generate the Documentation File
 
-## License
+Finally, run the shell script to fetch the content of each URL and build the final documentation file. The script will automatically determine the latest version of the provider and include it in the output filename (e.g., `snowflake_2.5.0.md`).
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+```sh
+bash process_urls.sh
+```
+
+Upon completion, you will find a new markdown file in your directory with the consolidated documentation. The script will print the name of the generated file, for example: `Documentation generated in snowflake_2.5.0.md`.


### PR DESCRIPTION
This commit replaces the README with a new README that accurately describes the purpose and usage of the scripts.

The new README specifies:
- The tool is for building documentation for the Snowflake Terraform Provider.
- Prerequisites for running the scripts (`curl`, `grep`, `awk`, `sed`, `python`).
- Step-by-step instructions on how to generate the documentation from scratch, including how to obtain the necessary `github_tree.json` file.